### PR TITLE
Fix: Panic when no secretRef field is defined for a source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode


### PR DESCRIPTION
Closes #13

The panic was happening because the `secretRef` field was not defined for the GitRepository. Since secretRef is an optional field, we need to make sure that the default value for secretRef is used if no secretRef has been specified in the GitRepository Manifest.

## After

```
> ./dist kustomization --name podinfo
INFO[0000] Warning: SecretRef is not defined in the GitRepository spec. Proceeding without the SSH private key. 
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  labels:
    argocd.argoproj.io/secret-type: repository
  name: mta-migration
  namespace: argocd
stringData:
  sshPrivateKey: ""
  type: git
  url: https://github.com/stefanprodan/podinfo
type: Opaque
---
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  creationTimestamp: null
  name: mta-migration
  namespace: argocd
spec:
  generators:
  - git:
      directories:
      - path: kustomize/*
      - exclude: true
        path: kustomize/flux-system
      repoURL: https://github.com/stefanprodan/podinfo
      revision: master
      template:
        metadata: {}
        spec:
          destination: {}
          project: ""
  template:
    metadata:
      name: '{{path.basename}}'
    spec:
      destination:
        namespace: default
        server: https://kubernetes.default.svc
      project: default
      source:
        path: '{{path}}'
        repoURL: https://github.com/stefanprodan/podinfo
        targetRevision: master
      syncPolicy:
        automated:
          prune: true
          selfHeal: true
        retry:
          backoff:
            duration: 5s
            factor: 2
            maxDuration: 3m
          limit: 5
        syncOptions:
        - CreateNamespace=true
        - Validate=false
status: {}
```