### PR TITLE
Fix: Produce valid manifest when helmrepository and the helmrelease are in different namespaces

### DIFF
--- a/cmd/helmrelease.go
+++ b/cmd/helmrelease.go
@@ -190,7 +190,7 @@ with kubectl.`,
 func GetHelmRepoNamespace(helmRelease *helmv2.HelmRelease) string {
 	helmRepoNamespace := helmRelease.Spec.Chart.Spec.SourceRef.Namespace
 	if helmRepoNamespace == "" {
-		helmRepoNamespace = "default"
+		helmRepoNamespace = helmRelease.Namespace
 	}
 
 	return helmRepoNamespace

--- a/cmd/helmrelease.go
+++ b/cmd/helmrelease.go
@@ -94,9 +94,11 @@ with kubectl.`,
 			log.Fatal(err)
 		}
 
+		helmRepoNamespace := GetHelmRepoNamespace(helmRelease)
+
 		// Get the helmrepo based on type, report if error
 		helmRepo := &sourcev1.HelmRepository{}
-		err = k.Get(ctx, types.NamespacedName{Namespace: helmReleaseNamespace, Name: helmRelease.Spec.Chart.Spec.SourceRef.Name}, helmRepo)
+		err = k.Get(ctx, types.NamespacedName{Namespace: helmRepoNamespace, Name: helmRelease.Spec.Chart.Spec.SourceRef.Name}, helmRepo)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -183,6 +185,15 @@ with kubectl.`,
 		}
 
 	},
+}
+
+func GetHelmRepoNamespace(helmRelease *helmv2.HelmRelease) string {
+	helmRepoNamespace := helmRelease.Spec.Chart.Spec.SourceRef.Namespace
+	if helmRepoNamespace == "" {
+		helmRepoNamespace = "default"
+	}
+
+	return helmRepoNamespace
 }
 
 func init() {

--- a/cmd/helmrelease_test.go
+++ b/cmd/helmrelease_test.go
@@ -37,5 +37,5 @@ func TestHelmGetRepoNamespace(t *testing.T) {
 	}
 
 	namespace = GetHelmRepoNamespace(helmReleaseWithoutNamespace)
-	assert.Equal(t, "default", namespace, "Expected the namespace to be 'default'")
+	assert.Equal(t, helmReleaseWithoutNamespace.Namespace, namespace, "Expected the namespace to be 'default'")
 }

--- a/cmd/helmrelease_test.go
+++ b/cmd/helmrelease_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	"github.com/magiconair/properties/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+)
+
+func TestHelmGetRepoNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	helmv2.AddToScheme(scheme)
+
+	helmReleaseWithNamespace := &helmv2.HelmRelease{
+		Spec: helmv2.HelmReleaseSpec{
+			Chart: helmv2.HelmChartTemplate{
+				Spec: helmv2.HelmChartTemplateSpec{
+					SourceRef: helmv2.CrossNamespaceObjectReference{
+						Namespace: "custom-namespace",
+					},
+				},
+			},
+		},
+	}
+
+	namespace := GetHelmRepoNamespace(helmReleaseWithNamespace)
+	assert.Equal(t, "custom-namespace", namespace, "Expected the namespace to be 'custom-namespace'")
+
+	helmReleaseWithoutNamespace := &helmv2.HelmRelease{
+		Spec: helmv2.HelmReleaseSpec{
+			Chart: helmv2.HelmChartTemplate{
+				Spec: helmv2.HelmChartTemplateSpec{
+					SourceRef: helmv2.CrossNamespaceObjectReference{},
+				},
+			},
+		},
+	}
+
+	namespace = GetHelmRepoNamespace(helmReleaseWithoutNamespace)
+	assert.Equal(t, "default", namespace, "Expected the namespace to be 'default'")
+}


### PR DESCRIPTION
Closes #12
## Before

```
> mta helmrelease --name diff-release --namespace non-existent
FATA[0000] helmrepositories.source.toolkit.fluxcd.io "podinfo" not found 
```

## After

```
 > mta helmrelease --name diff-release --namespace non-existent
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  creationTimestamp: null
  name: -diff-release
  namespace: argocd
spec:
  destination:
    server: https://kubernetes.default.svc
  project: default
  source:
    chart: podinfo
    helm:
      values: |
        replicaCount: 2
    repoURL: https://stefanprodan.github.io/podinfo
    targetRevision: 6.5.*
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
    syncOptions:
    - CreateNamespace=false
    - Validate=false
status:
  health: {}
  summary: {}
  sync:
    comparedTo:
      destination: {}
      source:
        repoURL: ""
    status: ""
```