### PR TITLE
chore: mark `name` flag as required

### DIFF
--- a/cmd/helmrelease.go
+++ b/cmd/helmrelease.go
@@ -65,8 +65,8 @@ with kubectl.`,
 		helmReleaseNamespace, _ := cmd.Flags().GetString("namespace")
 		confirmMigrate, _ := cmd.Flags().GetBool("confirm-migrate")
 
-		if helmReleaseName == "" || helmReleaseNamespace == "" {
-			log.Fatal("Both --name and --namespace flags must be provided")
+		if helmReleaseName == "" {
+			log.Fatal("Flag --name must be provided")
 		}
 
 		// Set up the default context
@@ -208,7 +208,6 @@ func GetHelmRepoNamespace(helmRelease *helmv2.HelmRelease) string {
 
 func init() {
 	rootCmd.AddCommand(helmreleaseCmd)
-	rootCmd.MarkPersistentFlagRequired("name")
 
 	helmreleaseCmd.Flags().Bool("confirm-migrate", false, "Automatically Migrate the HelmRelease to an ApplicationSet")
 }

--- a/cmd/kustomization.go
+++ b/cmd/kustomization.go
@@ -69,6 +69,10 @@ with kubectl.`,
 		kustomizationNamespace, _ := cmd.Flags().GetString("namespace")
 		confirmMigrate, _ := cmd.Flags().GetBool("confirm-migrate")
 
+		if kustomizationName == "" {
+			log.Fatal("Flag --name must be provided")
+		}
+
 		// Set up the default context
 		ctx := context.TODO()
 

--- a/cmd/kustomization.go
+++ b/cmd/kustomization.go
@@ -218,7 +218,6 @@ with kubectl.`,
 
 func init() {
 	rootCmd.AddCommand(kustomizationCmd)
-	rootCmd.MarkPersistentFlagRequired("name")
 
 	kustomizationCmd.Flags().Bool("confirm-migrate", false, "Automatically Migrate the Kustomization to an ApplicationSet")
 	kustomizationCmd.Flags().StringSlice("exclude-dirs", []string{}, "Additional Directories (besides flux-system) to exclude from the GitDir generator. Can be single or comma separated")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,20 +60,12 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.mta.yaml)")
 
 	rootCmd.PersistentFlags().String("kubeconfig", "", "Path to the kubeconfig file to use (if not the standard one).")
 	rootCmd.PersistentFlags().String("name", "", "Name of Kustomization or HelmRelease to export")
 	rootCmd.PersistentFlags().String("namespace", "flux-system", "Namespace of where the Kustomization or HelmRelease is")
 	rootCmd.PersistentFlags().String("argocd-namespace", "argocd", "Namespace where Argo CD is installed")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Displays version.",
-	Long:  `This command will display the version of the CLI in json format`,
+	Long:  `This command will display the version of the CLI`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(rootCmd.Version)
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -28,9 +27,7 @@ var versionCmd = &cobra.Command{
 	Short: "Displays version.",
 	Long:  `This command will display the version of the CLI in json format`,
 	Run: func(cmd *cobra.Command, args []string) {
-		versionMap := map[string]string{rootCmd.Use: rootCmd.Version}
-		versionJson, _ := json.Marshal(versionMap)
-		fmt.Println(string(versionJson))
+		fmt.Println(rootCmd.Version)
 	},
 }
 


### PR DESCRIPTION
This PR does the following changes:

1. The `name`  flag as required for `mta helmrelease` and `mta kustomization` command. The `--namespace` flag has a default value of `flux-system` namespace, hence if a user never initialize that flag, this flag will never be nil. So there's no point of checking if the `--namespace` flag has a nil value.
2. Remove the `MarkPersistentFlag()` from the subcommands.
3. Instead of printing the version in the JSON format, simply print the version in the string format without marshalling. In other words, marshalling is not required when printing the version of mta.

## After
![image](https://github.com/user-attachments/assets/42ddbfb8-32a0-4822-8a29-b0299b3cae94)
![image](https://github.com/user-attachments/assets/35582013-fdfa-421b-9c32-997e0b6e4c6a)
