### PR TITLE
docs: add mta example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ $ mta kustomization --name flux-system --exclude-dirs flux-system-extras --confi
 
 > *NOTE* To exclude more directories, you an pass a comma separated list to `--exclude-dirs`. Example: `--exclude-dirs foo,bar,bazz`. You can also pass `--exclude-dirs` to the `scan` command as well.
 
+For a detailed list of examples, read the [examples](./examples) docs.
+
 ## Auto Migration
 
 You can have the `scan` subcommand automatically migrate everything for you

--- a/cmd/helmrelease.go
+++ b/cmd/helmrelease.go
@@ -65,10 +65,6 @@ with kubectl.`,
 		helmReleaseNamespace, _ := cmd.Flags().GetString("namespace")
 		confirmMigrate, _ := cmd.Flags().GetBool("confirm-migrate")
 
-		if helmReleaseName == "" || helmReleaseNamespace == "" {
-			log.Fatal("Both --name and --namespace flags must be provided")
-		}
-
 		// Set up the default context
 		ctx := context.TODO()
 

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -1,0 +1,77 @@
+The helm directory contains valid manifest files each of which
+creates a `HelmRepository` and `HelmRelease` resource that you can
+apply to your cluster and see how `mta` helps in converting those resources
+into compatible Argo CD CRs.
+
+## How to use mta
+
+### Example 1:
+
+In this example, we are going to use the `manifest-1.yaml` for reference. This manifest simply creates
+a `HelmRepository` resource and `HelmRelease` resource in the `default` namespace. The `HelmRelease`
+resource simply references a resource of kind `HelmRepository` and name `podinfo`.
+
+Once you've applied the manifest:
+
+1. Run the `mta scan` command to look for all the Kustomization and Helmreleases resources
+    ```
+    ┌───────────────┬─────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
+    │ KIND          │ NAME    │ NAMESPACE │ STATUS                                                                 │
+    ├───────────────┼─────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
+    │ HelmRelease   │ podinfo │ default   │  Fulfilling prerequisites                                              │
+    └───────────────┴─────────┴───────────┴────────────────────────────────────────────────────────────────────────┘
+    ```
+
+2. Convert the helmrelease resource into Argo CD compatible CR using the following command:
+    ```
+    mta helmrelease --name podinfo --namespace default
+    ```
+   This will generate valid Argo CD comptaible CRs for you to apply to the cluster.
+
+
+### Example 2:
+
+In this example, we are going to use the `manifest-2.yaml` for reference. This manifest simply creates
+a `HelmRepository` resource in the `helm` namespace and `HelmRelease` resource in the `default` namespace.
+The `HelmRelease` resource simply references a `HelmRepository` named `helmrepo` that we created above
+in the `helm` namespace.
+
+Once you've applied the manifest:
+
+1. Run the `mta scan` command to look for all the Kustomization and HelmRelease resources
+    ```
+   ┌───────────────┬──────────────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
+   │ KIND          │ NAME             │ NAMESPACE │ STATUS                                                                 │
+   ├───────────────┼──────────────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
+   │ HelmRelease   │ helmrelease      │ default   │ Applied revision: master@sha1:b99bf8c252d47db1cccfb6546aec650679645e61 │
+   └───────────────┴──────────────────┴───────────┴────────────────────────────────────────────────────────────────────────┘
+    ```
+
+2. Convert the HelmRelease resource into Argo CD compatible CRs using the following command:
+    ```
+    mta helmrelease --name helmrelease --namespace default
+    ```
+   This will generate valid Argo CD comptaible CRs for you to apply to the cluster.
+
+### Troubleshooting:
+1. If you ever come across the following error message when converting to Argo CD compatible CRs
+
+    ```
+    FATA[0000] helmrepositories.source.toolkit.fluxcd.io "<helmrepository-name>" not found 
+    ```
+
+    Ensure that the `HelmRepository` that your `HelmRelease` resource references to exists in the namespace
+    you've specified in the `sourceRef` field. If you've not specified a namespace in the `sourceRef` field, `mta` will search
+    for the `HelmRepository` in `HelmRelease` resource namespace. For more information, refer to the:
+
+    - [Helm Reference docs](https://fluxcd.io/flux/components/helm/helmreleases/).
+    - [Helm API Reference docs](https://fluxcd.io/flux/components/helm/api/v2/)
+
+2. If you don't specify the `--namespace` flag to `mta helmrelease` command , mta will try to look for a `HelmRelease` resource in the `flux-system` namespace.
+Hence, If you get the following error message without specifying the namespace flag
+
+    ```
+    FATA[0000] helmreleases.helm.toolkit.fluxcd.io "<helmrelease-name>" not found 
+    ```
+
+    Ensure that the `HelmRelease` resource exists in the `flux-system` namespace.

--- a/examples/helm/manifest-1.yaml
+++ b/examples/helm/manifest-1.yaml
@@ -1,0 +1,42 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 1m
+  url: https://stefanprodan.github.io/podinfo
+  secretRef:
+    name: example-user
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-user
+  namespace: default
+type: Opaque
+stringData:
+  username: example
+  password: "123456"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: podinfo
+      version: '4.0.1'
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 2

--- a/examples/helm/manifest-2.yaml
+++ b/examples/helm/manifest-2.yaml
@@ -1,0 +1,42 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: helmrepo
+  namespace: helm
+spec:
+  interval: 1m
+  url: https://stefanprodan.github.io/podinfo
+  secretRef:
+    name: example-user
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-user
+  namespace: default
+type: Opaque
+stringData:
+  username: example
+  password: "123456"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: helmrelease
+  namespace: default
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: podinfo
+      version: '4.0.1'
+      sourceRef:
+        kind: HelmRepository
+        name: helmrepo
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 2

--- a/examples/kustomization/README.md
+++ b/examples/kustomization/README.md
@@ -1,0 +1,77 @@
+The kustomization directory contains valid manifest files each of which
+creates a `GitRepository` and `Kustomization` resource that you can
+apply to your cluster and see how `mta` helps in converting those resources
+into compatible Argo CD CRs.
+
+## How to use mta
+
+### Example 1:
+
+In this example, we are going to use the `manifest-1.yaml` for reference. This manifest simply creates
+a `GitRepository` resource and `Kustomization` resource in the `default` namespace. The `Kustomization`
+resource simply references a resource of kind `GitRepository` and name `podinfo`.
+
+Once you've applied the manifest:
+
+1. Run the `mta scan` command to look for all the Kustomization and HelmRelease resources
+    ```
+    ┌───────────────┬─────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
+    │ KIND          │ NAME    │ NAMESPACE │ STATUS                                                                 │
+    ├───────────────┼─────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
+    │ Kustomization │ podinfo │ default   │ Applied revision: master@sha1:b99bf8c252d47db1cccfb6546aec650679645e61 │
+    └───────────────┴─────────┴───────────┴────────────────────────────────────────────────────────────────────────┘
+    ```
+
+2. Convert the Kustomization resource into Argo CD compatible CR using the following command:
+    ```
+    mta kustomization --name podinfo --namespace default
+    ```
+   This will generate valid Argo CD comptaible CRs for you to apply to the cluster.
+
+
+### Example 2:
+
+In this example, we are going to use the `manifest-2.yaml` for reference. This manifest simply creates
+a `GitRepository` resource in the `git` namespace and `Kustomization` resource in the `default` namespace.
+The `Kustomization` resource simply references a `GitRepository` named `git-repository` that we created above
+in the `git` namespace.
+
+Once you've applied the manifest:
+
+1. Run the `mta scan` command to look for all the Kustomization and Helmreleases resources
+    ```
+   ┌───────────────┬──────────────────┬───────────┬────────────────────────────────────────────────────────────────────────┐
+   │ KIND          │ NAME             │ NAMESPACE │ STATUS                                                                 │
+   ├───────────────┼──────────────────┼───────────┼────────────────────────────────────────────────────────────────────────┤
+   │ Kustomization │ my-kustomization │ default   │ Applied revision: master@sha1:b99bf8c252d47db1cccfb6546aec650679645e61 │
+   └───────────────┴──────────────────┴───────────┴────────────────────────────────────────────────────────────────────────┘
+    ```
+
+2. Convert the Kustomization resource into Argo CD compatible CRs using the following command:
+    ```
+    mta kustomization --name my-kustomization --namespace default
+    ```
+   This will generate valid Argo CD comptaible CRs for you to apply to the cluster.
+
+### Troubleshooting:
+1. If you ever come across the following error message when converting to Argo CD compatible CRs
+
+    ```
+    FATA[0000] gitrepositories.source.toolkit.fluxcd.io "<gitrepository-name>" not found 
+    ```
+
+   Ensure that the `GitRepository` that your `Kustomization` resources references to exists in the namespace
+   you've specified in the `sourceRef` field. If you've not specified a namespace in the `sourceRef` namespace, `mta` will search
+   for the `GitRepository` in `Kustomization` resource namespace. For more information, refer to the:
+
+    - [Kustomization Reference docs](https://fluxcd.io/flux/components/kustomize/kustomizations/).
+    - [Kustomization API Reference docs](https://fluxcd.io/flux/components/kustomize/api/v1/)
+
+2. If you don't specify the `--namespace` flag to `mta kustomization` command, mta will try to look for a `Kustomization` resource in the `flux-system` namespace.
+   Hence, If you get the following error message without specifying the namespace flag
+
+    ```
+    FATA[0000] kustomizations.kustomize.toolkit.fluxcd.io "<kustomization-name>" not found 
+    ```
+
+   Ensure that the `Kustomization` resource exists in the `flux-system` namespace.

--- a/examples/kustomization/manifest-1.yaml
+++ b/examples/kustomization/manifest-1.yaml
@@ -1,0 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
+  ref:
+    branch: master
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  interval: 10m
+  targetNamespace: default
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  path: "./kustomize"
+  prune: true
+  timeout: 1m

--- a/examples/kustomization/manifest-2.yaml
+++ b/examples/kustomization/manifest-2.yaml
@@ -1,0 +1,26 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: git-repository
+  namespace: git
+spec:
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
+  ref:
+    branch: master
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: my-kustomization
+  namespace: default
+spec:
+  interval: 10m
+  targetNamespace: default
+  sourceRef:
+    kind: GitRepository
+    name: git-repository
+    namespace: git
+  path: "./kustomize"
+  prune: true
+  timeout: 1m


### PR DESCRIPTION
Recently, we encountered several user-reported bugs related to migrating Flux components, particularly when dealing with CrossNamespaceSourceReference in their manifests. Currently, we lack concrete examples demonstrating how to use mta, making it challenging for users to troubleshoot migration issues effectively. While the [README.md](https://github.com/akuity/mta?tab=readme-ov-file#mta-migrate-to-argo-cd) provides a solid foundation, there is still a need for additional examples to guide users on using mta and resolving common errors.

This PR introduces example documentation for mta, along with a troubleshooting guide to help users address common issues during migration.